### PR TITLE
feat: avoid range request when file size is less than max range

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ export const fetch = async (url, options) => {
     return globalThis.fetch(url)
   }
 
+  // if fits in a single range, just fetch it so the response can be cached
+  if (size <= maxRangeSize) {
+    return globalThis.fetch(url, { signal: options?.signal })
+  }
+
   const ranges = []
   let offset = 0
   while (offset < size) {
@@ -35,11 +40,6 @@ export const fetch = async (url, options) => {
   const etag = headRes.headers.get('etag')
   if (etag && (etag.startsWith('"DirIndex') || !etag.startsWith('"bafy') || !etag.startsWith('"Qm'))) {
     return globalThis.fetch(url)
-  }
-
-  // if a single range, just fetch it so that the response can be cached
-  if (ranges.length === 1) {
-    return globalThis.fetch(url, { signal: options?.signal })
   }
 
   const initRange = `bytes=${ranges[0][0]}-${ranges[0][1]}`

--- a/index.js
+++ b/index.js
@@ -31,11 +31,6 @@ export const fetch = async (url, options) => {
     offset += maxRangeSize
   }
 
-  // if zero size, then just fetch it (get the headers)
-  if (size === 0) {
-    return globalThis.fetch(url)
-  }
-
   // if a directory index, or not unixfs then just fetch it
   const etag = headRes.headers.get('etag')
   if (etag && (etag.startsWith('"DirIndex') || !etag.startsWith('"bafy') || !etag.startsWith('"Qm'))) {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,11 @@ export const fetch = async (url, options) => {
     return globalThis.fetch(url)
   }
 
+  // if a single range, just fetch it so that the response can be cached
+  if (ranges.length === 1) {
+    return globalThis.fetch(url, { signal: options?.signal })
+  }
+
   const initRange = `bytes=${ranges[0][0]}-${ranges[0][1]}`
   // console.log(`${initRange} of: ${url}`)
   const initRes = await globalThis.fetch(url, { headers: { range: initRange } })


### PR DESCRIPTION
When the file size is less than the max range then do not make a range request. The 206 response code is not cachable so we should avoid when possible.